### PR TITLE
turned listing card into a template tag

### DIFF
--- a/lectureloot/app/templatetags/listing_card.py
+++ b/lectureloot/app/templatetags/listing_card.py
@@ -1,0 +1,7 @@
+from django import template
+
+register = template.Library()
+
+@register.inclusion_tag('app/listing_card.html')
+def render_listing(listing):
+    return {'listing': listing}

--- a/lectureloot/templates/app/listing_card.html
+++ b/lectureloot/templates/app/listing_card.html
@@ -1,0 +1,10 @@
+<div class="card">
+    {% if listing.image %}
+        <img src="{{ listing.image.url }}" class="card-img-top" alt="{{ listing.title }}">
+    {% endif %}
+    <div class="card-body">
+        <h5 class="card-title">{{ listing.title }}</h5>
+        <p class="card-text">Price: ${{ listing.price }}</p>
+        <a href="{% url 'app:listing_detail' listing.id %}" class="btn btn-primary">View More</a>
+    </div>
+</div>

--- a/lectureloot/templates/app/search.html
+++ b/lectureloot/templates/app/search.html
@@ -1,24 +1,16 @@
 {% extends 'app/base.html' %}
 {% load static %}
+{% load listing_card %}
 
 {% block body_block %}
 <div class="container mt-4">
     <h2>Search Results for "{{ query }}"</h2>
     
     {% if results %}
-        <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
-            {% for item in results %}
-                <div class="col">
-                    <div class="card h-100">
-                        {% if item.image %}
-                            <img src="{{ item.image.url }}" class="card-img-top" alt="{{ item.title }}">
-                        {% endif %}
-                        <div class="card-body">
-                            <h5 class="card-title">{{ item.title }}</h5>
-                            <p class="card-text">${{ item.price }}</p>
-                            <a href="" class="btn btn-primary">View Auction</a>
-                        </div>
-                    </div>
+        <div class="row g-4">
+            {% for listing in results %}
+                <div class="col col-12 col-md-6 col-lg-4">
+                    {% render_listing listing %}
                 </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
I created a template tag render_listing that can be called with a listing object to render a card wherever required.

Example usage:

`{% load listing_card %}

{% render_listing listing %}
`